### PR TITLE
Use datetime.timedelta instead of custom function

### DIFF
--- a/check-lastupdate
+++ b/check-lastupdate
@@ -1,28 +1,11 @@
 #!/usr/bin/python3
 
 import asyncio
+from datetime import timedelta
 from urllib.parse import urljoin
 
 import yaml
 import aiohttp
-
-def humantime(t: int) -> str:
-  '''seconds -> XhYmZs'''
-  m, s = divmod(t, 60)
-  h, m = divmod(m, 60)
-  d, h = divmod(h, 24)
-  ret = ''
-  if d:
-    ret += '%dd' % d
-  if h:
-    ret += '%dh' % h
-  if m:
-    ret += '%dm' % m
-  if s:
-    ret += '%ds' % s
-  if not ret:
-    ret = '0s'
-  return ret
 
 async def get_lastupdate(session, name, url):
   try:
@@ -62,7 +45,7 @@ async def main():
   print('\nLags:')
   tier0 = done.pop('tier0')
   for name, dt in sorted(done.items(), reverse=True, key=lambda x: x[1]):
-    print(f'{name} {humantime(tier0-dt)}')
+    print(f'{name} {timedelta(seconds=tier0 - dt)}')
 
   print('\nErrors:')
   for name, e in error.items():


### PR DESCRIPTION
I think it would be better to let the standard library do the job of calculating the elapsed time instead of writing a custom function which does the same job. What are your thoughts on this matter?