### PR TITLE
Add a space bewteen # and Server to allow mirrorlists to be ranked by `rankmirrors`

### DIFF
--- a/update-script
+++ b/update-script
@@ -29,7 +29,7 @@ Server = {url}$arch
 
 MIRRORLIST_ITEM_TEMPLATE = """\
 ## {title}
-#Server = {url}$arch
+# Server = {url}$arch
 """
 
 README_TEMPLATE = """### Arch Linux CN Community repo mirrors list


### PR DESCRIPTION
When using `rankmirrors` to rank mirrorlist, if there is no space between `#` and `Server=...`, rankmirrors will not be able to recognize it.

<details>
  <summary>An example for archlinuxcn</summary>

```bash
➜  ~ rankmirrors /etc/pacman.d/archlinuxcn-mirrorlist -v -r archlinuxcn | sudo tee /etc/pacman.d/archlinuxcn-mirrorlist
# Server list generated by rankmirrors on 2022-04-10
##
## Arch Linux CN community repository mirrorlist
## Generated on 2022-03-09
##
## Our main server (Amsterdam, the Netherlands) (ipv4, ipv6, http, https)
#Server = https://repo.archlinuxcn.org/$arch
## OpenTUNA (China CDN) (ipv4, https)
#Server = https://opentuna.cn/archlinuxcn/$arch
## 北京外国语大学 (北京) (ipv4, ipv6, http, https)
#Server = https://mirrors.bfsu.edu.cn/archlinuxcn/$arch
## 腾讯云 (Global CDN) (ipv4, http, https)
# https://mirrors.cloud.tencent.com/archlinuxcn/$arch ... 0.769723
## 网易 (China CDN) (ipv4, http, https)
#Server = https://mirrors.163.com/archlinux-cn/$arch
## 阿里云 (Global CDN) (ipv4, ipv6, http, https)
# https://mirrors.aliyun.com/archlinuxcn/$arch ... 5.161204
## 华为云 (Global CDN) (ipv4, http, https)
# https://repo.huaweicloud.com/archlinuxcn/$arch ... 1.385908
## 清华大学 (北京) (ipv4, ipv6, http, https)
#Server = https://mirrors.tuna.tsinghua.edu.cn/archlinuxcn/$arch
## 中国科学技术大学 (安徽合肥) (ipv4, ipv6, http, https)
# https://mirrors.ustc.edu.cn/archlinuxcn/$arch ... 0.590095
## 哈尔滨工业大学 (黑龙江哈尔滨) (ipv4, ipv6, http, https)
#Server = https://mirrors.hit.edu.cn/archlinuxcn/$arch
## 浙江大学 (浙江杭州) (ipv4, http, https)
#Server = https://mirrors.zju.edu.cn/archlinuxcn/$arch
## 重庆大学 (重庆) (ipv4, ipv6, https)
#Server = https://mirrors.cqu.edu.cn/archlinuxcn/$arch
## 重庆邮电大学 (重庆) (ipv4, http, https)
#Server = https://mirrors.cqupt.edu.cn/archlinuxcn/$arch
## SJTUG 软件源镜像服务 (上海) (ipv4, ipv6, https)
#Server = https://mirrors.sjtug.sjtu.edu.cn/archlinux-cn/$arch
## 南京大学 (江苏南京) (ipv4, ipv6, http, https)
#Server = https://mirrors.nju.edu.cn/archlinuxcn/$arch
## 莞工 GNU/Linux 协会 开源软件镜像站 (广东东莞) (ipv4, https)
#Server = https://mirrors.dgut.edu.cn/archlinuxcn/$arch
## 南方科技大学 (广东深圳) (ipv4, ipv6, http, https)
#Server = https://mirrors.sustech.edu.cn/archlinuxcn/$arch
## NCKU CCNS (Taiwan) (ipv4, http, https)
#Server = https://archlinux.ccns.ncku.edu.tw/archlinuxcn/$arch
## xTom (Hong Kong server) (Hong Kong) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.com.hk/archlinuxcn/$arch
## xTom (US server) (Fremont, CA, United States) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.com/archlinuxcn/$arch
## xTom (Netherlands server) (Amsterdam, the Netherlands) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.nl/archlinuxcn/$arch
## xTom (Germany server) (Duesseldorf, Germany) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.de/archlinuxcn/$arch
## xTom (Estonia server) (Tallinn, Estonia) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.ee/archlinuxcn/$arch
## xTom (Japan server) (Osaka, Japan) (ipv4, ipv6, http, https)
#Server = https://mirror.xtom.jp/archlinuxcn/$arch
## Open Computing Facility, UC Berkeley (Berkeley, CA, United States) (ipv4, ipv6, http, https)
#Server = https://mirrors.ocf.berkeley.edu/archlinuxcn/$arch
Server = https://mirrors.ustc.edu.cn/archlinuxcn/$arch
Server = https://mirrors.cloud.tencent.com/archlinuxcn/$arch
Server = https://repo.huaweicloud.com/archlinuxcn/$arch
Server = https://mirrors.aliyun.com/archlinuxcn/$arch
```
</details>

#28 