### PR TITLE
fix(archlinuxcn-mirrorlist): remove ``` and extra space

### DIFF
--- a/archlinuxcn-mirrorlist
+++ b/archlinuxcn-mirrorlist
@@ -1,6 +1,6 @@
 ##
 ## Arch Linux CN community repository mirrorlist
-## Generated on 2023-04-21
+## Generated on 2023-08-24
 ##
 
 ## Our main server (Amsterdam, the Netherlands) (ipv4, ipv6, http, https)
@@ -8,7 +8,7 @@
 
 ## CERNET (中国) (ipv4, ipv6, http, https)
 # Server = https://mirrors.cernet.edu.cn/archlinuxcn/$arch
-```
+
 ## OpenTUNA (China CDN) (ipv4, https)
 # Server = https://opentuna.cn/archlinuxcn/$arch
 
@@ -75,7 +75,7 @@
 ## 上海科技大学 (上海) (ipv4, http, https)
 # Server = https://mirrors.shanghaitech.edu.cn/archlinuxcn/$arch
 
-##  中国科学院软件研究所(北京) (ipv4, http, https)
+## 中国科学院软件研究所 (北京) (ipv4, http, https)
 # Server = https://mirror.iscas.ac.cn/archlinuxcn/$arch
 
 ## NCKU CCNS (Taiwan) (ipv4, http, https)


### PR DESCRIPTION
When using `archlinuxcn-mirrorlist-git 20230822-1`, pacman will output `warning: config file /etc/pacman.d/archlinuxcn-mirrorlist, line 11: directive '```' in section 'archlinuxcn' not recognized.`.

This commit fixes the warning.